### PR TITLE
Black github action

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -9,6 +9,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with:
-          options: "--check --verbose --line-length 127"
+          options: "--check --diff --verbose --line-length 127"
           src: "./scAR"
-          version: "21.5b1"
+          version: "22.3.0"

--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -9,6 +9,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
         with:
-          options: "--check --diff --verbose --line-length 127"
+          options: "--diff --verbose --line-length 127"
           src: "./scAR"
           version: "22.3.0"

--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -1,0 +1,14 @@
+name: Black lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: psf/black@stable
+        with:
+          options: "--check --verbose --line-length 127"
+          src: "./scAR"
+          version: "21.5b1"


### PR DESCRIPTION
Addition of black github action that runs on every push and every pull request. It shows in the stdout all the changes that need to be made (--diff), but returns exit code 0, even if errors are observed.